### PR TITLE
Fixed code deprecated in julia v6.0

### DIFF
--- a/src/runsims.jl
+++ b/src/runsims.jl
@@ -173,7 +173,12 @@ function tumourgrow_birthdeath(b, d, Nmax, μ; numclones=1, clonalmutations = μ
     clonefreq[1] = 1
 
     executed = false
-    changemutrate = !BitArray(numclones + 1)
+
+    if VERSION < v"0.6-"
+        changemutrate = !BitArray(numclones + 1)  # Deprecated as of v0.6
+    else
+        changemutrate = .!BitArray(numclones + 1)
+    end
 
     while N < Nmax
 
@@ -414,7 +419,13 @@ function run1simulation(IP::InputParameters, minclonesize, maxclonesize)
 
     #remove clones that have frequency < detectionlimit
 #    detectableclones = (pctfit.>(IP.detectionlimit)) & (pctfit.<0.95)
-    detectableclones = (pctfit.>minclonesize) & (pctfit.<maxclonesize)
+
+    if VERSION < v"0.6-"
+        detectableclones = (pctfit.>minclonesize) & (pctfit.<maxclonesize)  # Deprecated as of v0.6
+    else
+        detectableclones = (pctfit.>minclonesize) .& (pctfit.<maxclonesize)
+    end
+
     pctfit = pctfit[detectableclones]
 
     if sum(detectableclones) != IP.numclones

--- a/src/runsimssample.jl
+++ b/src/runsimssample.jl
@@ -94,7 +94,13 @@ function tumourgrow_birthdeathsample(b, d, Nmax, μ; numclones=1, clonalmutation
     clonefreq[1] = 1
 
     executed = false
-    changemutrate = !BitArray(numclones + 1)
+
+    if VERSION < v"0.6-"
+        changemutrate = !BitArray(numclones + 1)  # Deprecated as of v0.6
+    else
+        changemutrate = .!BitArray(numclones + 1)
+    end
+
 
     while N < Nmax
 

--- a/src/samplesim.jl
+++ b/src/samplesim.jl
@@ -68,7 +68,7 @@ function sampledhist(AF, cellnum ; detectionlimit = 0.1, ploidy = 2.0, read_dept
 
     #data for histogram
     x = 0.005:0.01:1.005
-    y = fit(Histogram, VAF, x)
+    y = fit(Histogram, VAF, x, closed=:right)
     DFhist = DataFrame(VAF = x[1:end-1], freq = y.weights)
 
     SampledData(DFhist, VAF, samp_alleles, depth)
@@ -103,7 +103,7 @@ function sampledhist(AF, cellnum, ρ ; detectionlimit = 0.1, ploidy = 2.0, read_
 
     #data for histogram
     x = 0.005:0.01:1.005
-    y = fit(Histogram, VAF, x)
+    y = fit(Histogram, VAF, x, closed=:right)
     DFhist = DataFrame(VAF = x[1:end-1], freq = y.weights)
 
     SampledData(DFhist, VAF, samp_alleles, depth)
@@ -116,8 +116,8 @@ function cumulativedist(sresult; fmin = 0.1, fmax = 0.3)
 
     #calculate cumulative sum
     steps = fmax:-0.001:fmin
-    cumsum = Array(Int64, 0)
-    v = Array(Float64, 0)
+    cumsum = Array{Int64}(0)
+    v = Array{Float64}(0)
 
     for i in steps
         push!(cumsum, sum(VAF .>= i))


### PR DESCRIPTION
I am using julia version v"0.6.0" and got several warnings due to deprecated syntax. The following changes resolve these and should be compatible with previous versions as well.